### PR TITLE
Use attohttpc instead of ureq, allowing scrobbling behind a proxy

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ categories = ["api-bindings", "multimedia"]
 edition = "2021"
 
 [dependencies]
-attohttpc = "0.19"
+attohttpc = { version = "0.19", features = ["form"] }
 md5 = "0.7"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ categories = ["api-bindings", "multimedia"]
 edition = "2021"
 
 [dependencies]
-ureq = "^1"
+attohttpc = "0.19"
 md5 = "0.7"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/src/client.rs
+++ b/src/client.rs
@@ -175,7 +175,8 @@ impl LastFm {
         params.insert("api_sig".to_string(), signature);
 
         attohttpc::post(url)
-            .params(params)
+            .form(&params)
+            .map_err(|err| err.to_string())?
             .send()
             .and_then(|resp| resp.error_for_status())
             .map_err(|err| err.to_string())


### PR DESCRIPTION
Replaces [ureq](https://crates.io/crates/ureq) with [attohttpc](https://crates.io/crates/attohttpc). Attohttpc is similar to ureq in that it is very lightweight. It is based on cURL. However, unlike ureq, attohttpc picks up on proxy settings automatically, allowing scrobbling behind a proxy.